### PR TITLE
Add CI status badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Core
+[![Funless CI](https://github.com/funlessdev/funless-core/actions/workflows/check.yml/badge.svg)](https://github.com/funlessdev/funless-core/actions/workflows/check.yml)
 
 To run the project:
 


### PR DESCRIPTION
This PR adds the badge for the Funless CI pipeline on top of the README