### PR TITLE
Add simple ivk params validation

### DIFF
--- a/core-api.yaml
+++ b/core-api.yaml
@@ -61,6 +61,16 @@ paths:
               examples:
                 Invocation of hello world:
                   value: '{"result": "Hello, World!"}'
+        "400":
+          description: The invocation request was invalid
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: The error message
         "500":
           description: The function invocation failed for some unspecified internal error
           content:

--- a/lib/core/adapters/commands/test.ex
+++ b/lib/core/adapters/commands/test.ex
@@ -22,6 +22,6 @@ defmodule Core.Adapters.Commands.Test do
 
   @impl true
   def send_invocation_command(_worker, ivk_params) do
-    {:ok, %{"result" => ivk_params["function"]}}
+    {:ok, %{"result" => ivk_params.function}}
   end
 end

--- a/lib/core/adapters/commands/worker.ex
+++ b/lib/core/adapters/commands/worker.ex
@@ -39,7 +39,7 @@ defmodule Core.Adapters.Commands.Worker do
   @doc false
   def invoke_command(ivk_params) do
     function = %{
-      name: ivk_params["function"],
+      name: ivk_params.function,
       image: "nodejs",
       main_file: "index.js",
       archive: "js/hello.js"

--- a/lib/core/adapters/commands/worker.ex
+++ b/lib/core/adapters/commands/worker.ex
@@ -48,7 +48,7 @@ defmodule Core.Adapters.Commands.Worker do
     {:invoke, function}
   end
 
-  defp call_worker(worker_addr, command = {cmd, payload}) do
+  defp call_worker(worker_addr, {cmd, payload} = command) do
     Logger.info(
       "sending command #{cmd} to #{inspect(worker_addr)} with payload #{inspect(payload)}"
     )

--- a/lib/core/adapters/requests/http/server.ex
+++ b/lib/core/adapters/requests/http/server.ex
@@ -59,6 +59,11 @@ defmodule Core.Adapters.Requests.Http.Server do
     send_resp(conn, 503, body)
   end
 
+  defp reply_to_client({:error, :bad_params}, conn) do
+    body = Jason.encode!(%{"error" => "Failed to invoke function: bad request"})
+    send_resp(conn, 400, body)
+  end
+
   defp reply_to_client(_, conn) do
     body = Jason.encode!(%{"error" => "Something went wrong..."})
     send_resp(conn, 500, body)

--- a/lib/core/domain/api.ex
+++ b/lib/core/domain/api.ex
@@ -51,11 +51,6 @@ defmodule Core.Domain.Api do
     Nodes.worker_nodes() |> Scheduler.select() |> invoke_on_chosen(ivk_params)
   end
 
-  def invoke(%{"function" => f} = ivk_params) do
-    Logger.info("API: received invocation for function #{f}")
-    Nodes.worker_nodes() |> Scheduler.select() |> invoke_on_chosen(ivk_params)
-  end
-
   def invoke(_), do: {:error, :bad_params}
 
   defp invoke_on_chosen(:no_workers, _) do

--- a/lib/core/domain/api.ex
+++ b/lib/core/domain/api.ex
@@ -15,23 +15,35 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+defmodule Core.Domain.InvokeParams do
+  @moduledoc """
+    Invocation parameters struct, used for parameter validation.
+
+    ## Fields
+      - namespace: function namespace
+      - function: function name
+      - args: function arguments
+  """
+  @type t :: %__MODULE__{
+          namespace: String.t(),
+          function: String.t(),
+          args: Map.t()
+        }
+  @enforce_keys [:function]
+  defstruct [:function, namespace: "_", args: %{}]
+end
 
 defmodule Core.Domain.Api do
   @moduledoc """
   Provides functions to deal with requests to workers.
   """
   require Logger
+  alias Core.Domain.InvokeParams
   alias Core.Domain.Nodes
   alias Core.Domain.Ports.Commands
   alias Core.Domain.Scheduler
 
-  @type ivk_params :: %{
-          :namespace => String.t(),
-          :function => String.t(),
-          :args => Map.t()
-        }
-
-  @spec invoke(ivk_params) :: {:ok, %{:result => String.t()}} | {:error, any}
+  @spec invoke(Map.t()) :: {:ok, %{:result => String.t()}} | {:error, any}
   @doc """
   Sends an invocation request for the `name` function in the `ns` namespace,
   specified in the invocation parameters.
@@ -41,13 +53,16 @@ defmodule Core.Domain.Api do
   ## Parameters
     - ivk_params: a map with namespace name, function name and a map of args.
   """
-  def invoke(%{"namespace" => ns, "function" => f, "args" => args} = ivk_params) do
-    Logger.info("API: received invocation for function #{f} in namespace #{ns} with args #{args}")
-    Nodes.worker_nodes() |> Scheduler.select() |> invoke_on_chosen(ivk_params)
-  end
+  def invoke(%{"function" => f} = raw_params) do
+    # not pretty, but we avoid calling Map.keys() on each invocation
+    keys = ["function", "namespace", "args"]
 
-  def invoke(%{"namespace" => ns, "function" => f} = ivk_params) do
-    Logger.info("API: received invocation for function #{f} in namespace #{ns}")
+    parsed_params =
+      raw_params |> Map.take(keys) |> Map.new(fn {k, v} -> {String.to_existing_atom(k), v} end)
+
+    ivk_params = struct(InvokeParams, parsed_params)
+    Logger.info("API: received invocation for function #{f} with params #{inspect(ivk_params)}")
+
     Nodes.worker_nodes() |> Scheduler.select() |> invoke_on_chosen(ivk_params)
   end
 

--- a/lib/core/domain/api.ex
+++ b/lib/core/domain/api.ex
@@ -41,10 +41,22 @@ defmodule Core.Domain.Api do
   ## Parameters
     - ivk_params: a map with namespace name, function name and a map of args.
   """
-  def invoke(ivk_params) do
-    Logger.info("API: received invocation for function '#{ivk_params["function"]}'")
+  def invoke(%{"namespace" => ns, "function" => f, "args" => args} = ivk_params) do
+    Logger.info("API: received invocation for function #{f} in namespace #{ns} with args #{args}")
     Nodes.worker_nodes() |> Scheduler.select() |> invoke_on_chosen(ivk_params)
   end
+
+  def invoke(%{"namespace" => ns, "function" => f} = ivk_params) do
+    Logger.info("API: received invocation for function #{f} in namespace #{ns}")
+    Nodes.worker_nodes() |> Scheduler.select() |> invoke_on_chosen(ivk_params)
+  end
+
+  def invoke(%{"function" => f} = ivk_params) do
+    Logger.info("API: received invocation for function #{f}")
+    Nodes.worker_nodes() |> Scheduler.select() |> invoke_on_chosen(ivk_params)
+  end
+
+  def invoke(_), do: {:error, :bad_params}
 
   defp invoke_on_chosen(:no_workers, _) do
     Logger.warn("API: no workers found")

--- a/lib/core/domain/ports/commands.ex
+++ b/lib/core/domain/ports/commands.ex
@@ -19,12 +19,11 @@ defmodule Core.Domain.Ports.Commands do
   @moduledoc """
   Port for sending commands to workers.
   """
-  @type ivk_params :: %{:namespace => String.t(), :function => String.t(), :args => Map.t()}
   @type worker :: Atom.t()
 
   @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
-  @callback send_invocation_command(worker, ivk_params) ::
+  @callback send_invocation_command(worker, Core.Domain.InvokeParams.t()) ::
               {:ok, %{:result => String.t()}} | {:error, atom}
 
   @doc """

--- a/lib/core/domain/scheduler.ex
+++ b/lib/core/domain/scheduler.ex
@@ -30,7 +30,7 @@ defmodule Core.Domain.Scheduler do
     :no_workers
   end
 
-  def select(workers = [first_w | _]) do
+  def select([first_w | _] = workers) do
     Logger.info("Scheduler: selecting between workers #{inspect(workers)}")
     first_w
   end

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -38,7 +38,9 @@ defmodule ApiTest do
 
     test "invoke should return {:ok, result} when there is at least a worker and no error occurs" do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
-      assert Api.invoke(%{"namespace" => "_", "function" => "test"}) == {:ok, %{"result" => "test"}}
+
+      assert Api.invoke(%{"namespace" => "_", "function" => "test"}) ==
+               {:ok, %{"result" => "test"}}
     end
 
     test "invoke should return {:error, err} when the underlying functions encounter errors" do
@@ -47,7 +49,8 @@ defmodule ApiTest do
       Core.Commands.Mock
       |> Mox.expect(:send_invocation_command, fn _, _ -> {:error, message: "generic error"} end)
 
-      assert Api.invoke(%{"namespace" => "_", "function" => "f"}) == {:error, message: "generic error"}
+      assert Api.invoke(%{"namespace" => "_", "function" => "f"}) ==
+               {:error, message: "generic error"}
     end
 
     test "invoke should return {:error, no workers} when no workers are found" do

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -47,7 +47,7 @@ defmodule ApiTest do
       Core.Commands.Mock
       |> Mox.expect(:send_invocation_command, fn _, _ -> {:error, message: "generic error"} end)
 
-      assert Api.invoke(%{}) == {:error, message: "generic error"}
+      assert Api.invoke(%{"function" => "f"}) == {:error, message: "generic error"}
     end
 
     test "invoke should return {:error, no workers} when no workers are found" do
@@ -67,6 +67,10 @@ defmodule ApiTest do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:core@somewhere] end)
 
       assert Api.invoke(%{"function" => "test"}) == {:error, :no_workers}
+    end
+
+    test "invoke with bad parameters should return {:error, :bad_params}" do
+      assert Api.invoke(%{"bad" => "arg"}) == {:error, :bad_params}
     end
   end
 end

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -38,7 +38,7 @@ defmodule ApiTest do
 
     test "invoke should return {:ok, result} when there is at least a worker and no error occurs" do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
-      assert Api.invoke(%{"function" => "test"}) == {:ok, %{"result" => "test"}}
+      assert Api.invoke(%{"namespace" => "_", "function" => "test"}) == {:ok, %{"result" => "test"}}
     end
 
     test "invoke should return {:error, err} when the underlying functions encounter errors" do
@@ -47,11 +47,11 @@ defmodule ApiTest do
       Core.Commands.Mock
       |> Mox.expect(:send_invocation_command, fn _, _ -> {:error, message: "generic error"} end)
 
-      assert Api.invoke(%{"function" => "f"}) == {:error, message: "generic error"}
+      assert Api.invoke(%{"namespace" => "_", "function" => "f"}) == {:error, message: "generic error"}
     end
 
     test "invoke should return {:error, no workers} when no workers are found" do
-      assert Api.invoke(%{"function" => "test"}) == {:error, :no_workers}
+      assert Api.invoke(%{"namespace" => "_", "function" => "test"}) == {:error, :no_workers}
     end
 
     test "invoke on node list with nodes other than workers should only use workers" do
@@ -60,13 +60,13 @@ defmodule ApiTest do
       Core.Commands.Mock
       |> Mox.expect(:send_invocation_command, fn worker, _ -> worker end)
 
-      assert Api.invoke(%{"function" => "test"}) == :worker@localhost
+      assert Api.invoke(%{"namespace" => "_", "function" => "test"}) == :worker@localhost
     end
 
     test "invoke on node list without workers should return {:error, no workers}" do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:core@somewhere] end)
 
-      assert Api.invoke(%{"function" => "test"}) == {:error, :no_workers}
+      assert Api.invoke(%{"namespace" => "_", "function" => "test"}) == {:error, :no_workers}
     end
 
     test "invoke with bad parameters should return {:error, :bad_params}" do

--- a/test/http_server_test.exs
+++ b/test/http_server_test.exs
@@ -90,6 +90,37 @@ defmodule HttpServerTest do
       assert body == %{"result" => "Hello, World!"}
     end
 
+    test "should return 400 bad request when bad parameters" do
+      # Create a test connection
+      conn = conn(:post, "/invoke", %{"bad" => "arg"})
+
+      # Invoke the plug
+      conn = Server.call(conn, @opts)
+
+      # Assert the response and status
+      assert conn.state == :sent
+      assert conn.status == 400
+      assert get_resp_header(conn, "content-type") == ["application/json"]
+      body = Jason.decode!(conn.resp_body)
+      assert body == %{"error" => "Failed to invoke function: bad request"}
+    end
+
+    test "should return 400 bad request when empty invoke parameters" do
+      # Create a test connection
+      conn = conn(:post, "/invoke")
+
+      # Invoke the plug
+      conn = Server.call(conn, @opts)
+
+      # Assert the response and status
+      assert conn.state == :sent
+      assert conn.status == 400
+      assert get_resp_header(conn, "content-type") == ["application/json"]
+      body = Jason.decode!(conn.resp_body)
+      assert body == %{"error" => "Failed to invoke function: bad request"}
+
+    end
+
     # change it with proper response
     test "should return 404 with wrong request" do
       # Create a test connection

--- a/test/http_server_test.exs
+++ b/test/http_server_test.exs
@@ -118,7 +118,6 @@ defmodule HttpServerTest do
       assert get_resp_header(conn, "content-type") == ["application/json"]
       body = Jason.decode!(conn.resp_body)
       assert body == %{"error" => "Failed to invoke function: bad request"}
-
     end
 
     # change it with proper response

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -24,7 +24,7 @@ defmodule WorkerTest do
   end
 
   test "should prepare correct invocation command" do
-    assert Worker.invoke_command(%{"function" => "test"}) ==
+    assert Worker.invoke_command(%{function: "test"}) ==
              {:invoke,
               %{
                 name: "test",


### PR DESCRIPTION
The server now returns a bad request reply if the params for the invoke does not contain at least the function name.

This closes #26 