### PR TITLE
Parse worker reply to handle error case 

### DIFF
--- a/core-api.yaml
+++ b/core-api.yaml
@@ -83,7 +83,7 @@ paths:
                     description: The error message
               examples:
                 Invocation with internal error:
-                  value: '{"error": "Something went wrong..."}'
+                  value: '{"error": "Failed to invoke function: internal worker error"}'
         "503":
           description: The function invocation failed because no worker was available
           content:

--- a/lib/core/adapters/requests/http/server.ex
+++ b/lib/core/adapters/requests/http/server.ex
@@ -64,6 +64,12 @@ defmodule Core.Adapters.Requests.Http.Server do
     send_resp(conn, 400, body)
   end
 
+  defp reply_to_client({:error, :worker_error}, conn) do
+    body = Jason.encode!(%{"error" => "Failed to invoke function: internal worker error"})
+    send_resp(conn, 500, body)
+  end
+
+  # currently unused, but could be used to handle errors in the future.
   defp reply_to_client(_, conn) do
     body = Jason.encode!(%{"error" => "Something went wrong..."})
     send_resp(conn, 500, body)

--- a/lib/core/domain/api.ex
+++ b/lib/core/domain/api.ex
@@ -75,6 +75,18 @@ defmodule Core.Domain.Api do
 
   defp invoke_on_chosen(worker, ivk_params) do
     Logger.info("API: found worker #{worker} for invocation")
-    Commands.send_invocation_command(worker, ivk_params)
+    wrk_reply = Commands.send_invocation_command(worker, ivk_params)
+    parse_wrk_reply(wrk_reply)
+  end
+
+  defp parse_wrk_reply({:ok, _} = reply) do
+    Logger.info("API: received success reply from worker")
+    reply
+  end
+
+  defp parse_wrk_reply({:error, err}) do
+    err_msg = err["error"] || "Unknown error"
+    Logger.error("API: received error reply from worker #{err_msg}")
+    {:error, :worker_error}
   end
 end

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -39,15 +39,16 @@ defmodule ApiTest do
     test "invoke should return {:ok, result} when there is at least a worker and no error occurs" do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
-      assert Api.invoke(%{"namespace" => "_", "function" => "test"}) ==
-               {:ok, %{"result" => "test"}}
+      assert Api.invoke(%{"function" => "test"}) == {:ok, %{"result" => "test"}}
     end
 
     test "invoke should return {:error, err} when the invocation on worker encounter errors" do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invocation_command, fn _, _ -> %{"error" => "generic error"} end)
+      |> Mox.expect(:send_invocation_command, fn _, _ ->
+        {:error, %{}}
+      end)
 
       assert Api.invoke(%{"function" => "f"}) == {:error, :worker_error}
     end
@@ -62,13 +63,13 @@ defmodule ApiTest do
       Core.Commands.Mock
       |> Mox.expect(:send_invocation_command, fn worker, _ -> {:ok, worker} end)
 
-      assert Api.invoke(%{"namespace" => "_", "function" => "test"}) == {:ok, :worker@localhost}
+      assert Api.invoke(%{"function" => "test"}) == {:ok, :worker@localhost}
     end
 
     test "invoke on node list without workers should return {:error, no workers}" do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:core@somewhere] end)
 
-      assert Api.invoke(%{"namespace" => "_", "function" => "test"}) == {:error, :no_workers}
+      assert Api.invoke(%{"function" => "test"}) == {:error, :no_workers}
     end
 
     test "invoke with bad parameters should return {:error, :bad_params}" do

--- a/test/http_server_test.exs
+++ b/test/http_server_test.exs
@@ -41,7 +41,9 @@ defmodule HttpServerTest do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invocation_command, fn _, _ -> {:error, %{"error" => "some worker error dude"} end)
+      |> Mox.expect(:send_invocation_command, fn _, _ ->
+        {:error, %{"error" => "some worker error dude"}}
+      end)
 
       conn = conn(:post, "/invoke", %{"namespace" => "_", "function" => "test", "args" => []})
 


### PR DESCRIPTION
This PR closes #28 

It uses 500 status code for the worker error case.