### PR TITLE
Add permanent function storage based on a Mnesia database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ core-*.tar
 /native/**/Cargo.lock
 /priv/native/*.so
 .elixir_ls/
+
+Mnesia.*/

--- a/config/config.exs
+++ b/config/config.exs
@@ -20,6 +20,7 @@ import Config
 
 config :core, Core.Domain.Ports.Commands, adapter: Core.Adapters.Commands.Worker
 config :core, Core.Domain.Ports.Cluster, adapter: Core.Adapters.Cluster
+config :core, Core.Domain.Ports.FunctionStorage, adapter: Core.Adapters.FunctionStorage.Mnesia
 
 config :logger, :console,
   format: "\n##### $time $metadata[$level] $levelpad$message\n",

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -20,6 +20,7 @@ import Config
 
 config :core, Core.Domain.Ports.Commands, adapter: Core.Adapters.Commands.Worker
 config :core, Core.Domain.Ports.Cluster, adapter: Core.Adapters.Cluster
+config :core, Core.Domain.Ports.FunctionStorage, adapter: Core.Adapters.FunctionStorage.Mnesia
 
 config :logger,
   backends: [:console],

--- a/config/test.exs
+++ b/config/test.exs
@@ -20,6 +20,7 @@ import Config
 
 config :core, Core.Domain.Ports.Commands, adapter: Core.Commands.Mock
 config :core, Core.Domain.Ports.Cluster, adapter: Core.Cluster.Mock
+config :core, Core.Domain.Ports.FunctionStorage, adapter: Core.FunctionStorage.Mock
 
 # Print only errors during test
 config :logger, level: :error

--- a/lib/core/adapters/commands/test.ex
+++ b/lib/core/adapters/commands/test.ex
@@ -22,6 +22,6 @@ defmodule Core.Adapters.Commands.Test do
 
   @impl true
   def send_invocation_command(_worker, function, _args) do
-    {:ok, %{"result" => function.name}}
+    {:ok, %{result: function.name}}
   end
 end

--- a/lib/core/adapters/commands/test.ex
+++ b/lib/core/adapters/commands/test.ex
@@ -21,7 +21,7 @@ defmodule Core.Adapters.Commands.Test do
   @behaviour Core.Domain.Ports.Commands
 
   @impl true
-  def send_invocation_command(_worker, ivk_params) do
-    {:ok, %{"result" => ivk_params.function}}
+  def send_invocation_command(_worker, function, _args) do
+    {:ok, %{"result" => function.name}}
   end
 end

--- a/lib/core/adapters/function_storage/mnesia.ex
+++ b/lib/core/adapters/function_storage/mnesia.ex
@@ -30,9 +30,11 @@ defmodule Core.Adapters.FunctionStorage.Mnesia do
   end
 
   defp create_table(:ok, nodes) do
+    # namespace_name acts as the primary key, and is the {function_name, function_namespace} tuple,
+    # which uniquely identifies each function
     t =
       :mnesia.create_table(Function,
-        attributes: [:namespaced_name, :function],
+        attributes: [:namespace_name, :function],
         access_mode: :read_write,
         ram_copies: nodes
       )

--- a/lib/core/adapters/function_storage/mnesia.ex
+++ b/lib/core/adapters/function_storage/mnesia.ex
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+defmodule Core.Adapters.FunctionStorage.Mnesia do
+  @moduledoc """
+  Adapter to access and insert functions on a Mnesia distributed storage.
+  """
+  require Logger
+  alias Core.Domain.FunctionStruct
+  @behaviour Core.Domain.Ports.FunctionStorage
+
+  @impl true
+  def init_database() do
+    create_schema()
+    |> create_table
+  end
+
+  @impl true
+  def get_function(function_name, function_namespace) do
+    case :mnesia.dirty_index_read(Function, {function_name, function_namespace}, :namespaced_name) do
+      [] -> {:error, :not_found}
+      [{Function, f, _} | _] -> {:ok, struct(FunctionStruct, f)}
+    end
+  end
+
+  @impl true
+  def insert_function(%FunctionStruct{name: name, namespace: namespace} = function) do
+    data = fn ->
+      :mnesia.write({Function, Map.from_struct(function), {name, namespace}})
+    end
+
+    :mnesia.transaction(data)
+  end
+
+  @impl true
+  def delete_function(function_name, function_namespace) do
+    data = fn ->
+      :mnesia.delete(Function, :namespaced_name, {function_name, function_namespace})
+    end
+
+    :mnesia.transaction(data)
+  end
+
+  defp create_schema() do
+    # TODO: should be all core nodes instead of just current node
+    :mnesia.create_schema([node()])
+  end
+
+  defp create_table(:ok) do
+    t =
+      :mnesia.create_table(Function,
+        attributes: [:function, :namespaced_name],
+        access_mode: :read_write,
+        index: [:namespaced_name],
+        ram_copies: [node()]
+      )
+
+    case t do
+      {_, :ok} -> :ok
+      {:aborted, reason} -> {:error, {:aborted, reason}}
+    end
+  end
+
+  defp create_table({:error, {_, {:already_exists, _}}}) do
+    create_table(:ok)
+  end
+
+  defp create_table({:error, err}) do
+    {:error, err}
+  end
+end

--- a/lib/core/adapters/function_storage/test.ex
+++ b/lib/core/adapters/function_storage/test.ex
@@ -15,19 +15,34 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-defmodule WorkerTest do
-  use ExUnit.Case, async: true
-  alias Core.Adapters.Commands.Worker
+defmodule Core.Adapters.FunctionStorage.Test do
   alias Core.Domain.FunctionStruct
+  @behaviour Core.Domain.Ports.FunctionStorage
 
-  test "should send to {:worker, worker atom}" do
-    assert Worker.worker_address(:worker@atom) == {:worker, :worker@atom}
+  @impl true
+  def init_database(_nodes) do
+    :ok
   end
 
-  test "should prepare correct invocation command" do
-    function = %FunctionStruct{name: "test", image: "nodejs", code: "some code", namespace: "_"}
+  @impl true
+  def get_function(function_name, function_namespace) do
+    f = %FunctionStruct{
+      name: function_name,
+      namespace: function_namespace,
+      code: "console.log(\"hello\")",
+      image: "nodejs"
+    }
 
-    assert Worker.invoke_command(function, %{}) ==
-             {:invoke, function, %{}}
+    {:ok, f}
+  end
+
+  @impl true
+  def insert_function(%FunctionStruct{name: function_name}) do
+    {:ok, function_name}
+  end
+
+  @impl true
+  def delete_function(function_name, _function_namespace) do
+    {:ok, function_name}
   end
 end

--- a/lib/core/adapters/function_storage/test.ex
+++ b/lib/core/adapters/function_storage/test.ex
@@ -16,6 +16,8 @@
 # under the License.
 #
 defmodule Core.Adapters.FunctionStorage.Test do
+  @moduledoc false
+
   alias Core.Domain.FunctionStruct
   @behaviour Core.Domain.Ports.FunctionStorage
 

--- a/lib/core/adapters/requests/http/server.ex
+++ b/lib/core/adapters/requests/http/server.ex
@@ -69,6 +69,15 @@ defmodule Core.Adapters.Requests.Http.Server do
     send_resp(conn, 500, body)
   end
 
+  defp reply_to_client({:error, :not_found}, conn) do
+    body =
+      Jason.encode!(%{
+        "error" => "Failed to invoke function: function not found in given namespace"
+      })
+
+    send_resp(conn, 404, body)
+  end
+
   # currently unused, but could be used to handle errors in the future.
   defp reply_to_client(_, conn) do
     body = Jason.encode!(%{"error" => "Something went wrong..."})

--- a/lib/core/application.ex
+++ b/lib/core/application.ex
@@ -21,6 +21,9 @@ defmodule Core.Application do
   # for more information on OTP Applications
   @moduledoc false
 
+  alias Core.Domain.Ports.FunctionStorage
+  alias Core.Domain.Nodes
+
   use Application
 
   @impl true
@@ -33,5 +36,18 @@ defmodule Core.Application do
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Core.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  @impl true
+  def start_phase(:init_db, _phase_type, _args) do
+    res =
+      Nodes.core_nodes()
+      |> FunctionStorage.init_database()
+
+    case res do
+      :ok -> :ok
+      {:error, {:aborted, {:already_exists, _}}} -> :ok
+      err -> err
+    end
   end
 end

--- a/lib/core/application.ex
+++ b/lib/core/application.ex
@@ -21,8 +21,8 @@ defmodule Core.Application do
   # for more information on OTP Applications
   @moduledoc false
 
-  alias Core.Domain.Ports.FunctionStorage
   alias Core.Domain.Nodes
+  alias Core.Domain.Ports.FunctionStorage
 
   use Application
 
@@ -39,7 +39,12 @@ defmodule Core.Application do
   end
 
   @impl true
-  def start_phase(:init_db, _phase_type, _args) do
+  def start_phase(:init_db, _phase_type, :test) do
+    :ok
+  end
+
+  @impl true
+  def start_phase(:init_db, _phase_type, _env) do
     res =
       Nodes.core_nodes()
       |> FunctionStorage.init_database()

--- a/lib/core/domain/api.ex
+++ b/lib/core/domain/api.ex
@@ -67,6 +67,10 @@ defmodule Core.Domain.Api do
         parse_wrk_reply(wrk_reply)
 
       {:error, :not_found} ->
+        Logger.error(
+          "API: function #{ivk_params.function} in namespace #{ivk_params.namespace} not found"
+        )
+
         {:error, :not_found}
 
       {:error, err} ->

--- a/lib/core/domain/api.ex
+++ b/lib/core/domain/api.ex
@@ -66,7 +66,14 @@ defmodule Core.Domain.Api do
         wrk_reply = Commands.send_invocation_command(worker, function, ivk_params.args)
         parse_wrk_reply(wrk_reply)
 
+      {:error, :not_found} ->
+        {:error, :not_found}
+
       {:error, err} ->
+        Logger.error(
+          "API: encountered error when getting function #{ivk_params.function}: #{inspect(err)}"
+        )
+
         {:error, err}
     end
   end

--- a/lib/core/domain/api.ex
+++ b/lib/core/domain/api.ex
@@ -15,24 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-defmodule Core.Domain.InvokeParams do
-  @moduledoc """
-    Invocation parameters struct, used for parameter validation.
-
-    ## Fields
-      - namespace: function namespace
-      - function: function name
-      - args: function arguments
-  """
-  @type t :: %__MODULE__{
-          namespace: String.t(),
-          function: String.t(),
-          args: Map.t()
-        }
-  @enforce_keys [:function]
-  defstruct [:function, namespace: "_", args: %{}]
-end
-
 defmodule Core.Domain.Api do
   @moduledoc """
   Provides functions to deal with requests to workers.

--- a/lib/core/domain/api.ex
+++ b/lib/core/domain/api.ex
@@ -74,11 +74,11 @@ defmodule Core.Domain.Api do
     {:error, :worker_error}
   end
 
-  def new_function(%{"name" => name, "code" => code, "language" => language} = raw_params) do
+  def new_function(%{"name" => name, "code" => code, "image" => image} = raw_params) do
     function = %FunctionStruct{
       name: name,
       namespace: raw_params["namespace"] || "_",
-      language: language,
+      image: image,
       code: code
     }
 

--- a/lib/core/domain/api.ex
+++ b/lib/core/domain/api.ex
@@ -97,6 +97,8 @@ defmodule Core.Domain.Api do
     FunctionStorage.insert_function(function)
   end
 
+  def new_function(_), do: {:error, :bad_params}
+
   def delete_function(name, namespace) do
     Logger.info("API: received deletion request for function #{name} in namespace #{namespace}")
     FunctionStorage.delete_function(name, namespace)

--- a/lib/core/domain/api.ex
+++ b/lib/core/domain/api.ex
@@ -59,8 +59,16 @@ defmodule Core.Domain.Api do
 
   defp invoke_on_chosen(worker, ivk_params) do
     Logger.info("API: found worker #{worker} for invocation")
-    wrk_reply = Commands.send_invocation_command(worker, ivk_params)
-    parse_wrk_reply(wrk_reply)
+    f = FunctionStorage.get_function(ivk_params.function, ivk_params.namespace)
+
+    case f do
+      {:ok, function} ->
+        wrk_reply = Commands.send_invocation_command(worker, function, ivk_params.args)
+        parse_wrk_reply(wrk_reply)
+
+      {:error, err} ->
+        {:error, err}
+    end
   end
 
   defp parse_wrk_reply({:ok, _} = reply) do

--- a/lib/core/domain/nodes.ex
+++ b/lib/core/domain/nodes.ex
@@ -33,6 +33,9 @@ defmodule Core.Domain.Nodes do
     |> Enum.map(fn node_name -> String.to_atom(node_name) end)
   end
 
+  @doc """
+  Obtains all nodes in the cluster and filters the ones with 'core' as their sname (including the current node).
+  """
   def core_nodes do
     [
       node()

--- a/lib/core/domain/nodes.ex
+++ b/lib/core/domain/nodes.ex
@@ -32,4 +32,14 @@ defmodule Core.Domain.Nodes do
     |> Enum.filter(fn node_name -> String.contains?(node_name, "worker") end)
     |> Enum.map(fn node_name -> String.to_atom(node_name) end)
   end
+
+  def core_nodes do
+    [
+      node()
+      | Cluster.all_nodes()
+        |> Enum.map(&Atom.to_string(&1))
+        |> Enum.filter(fn node_name -> String.contains?(node_name, "core") end)
+        |> Enum.map(fn node_name -> String.to_atom(node_name) end)
+    ]
+  end
 end

--- a/lib/core/domain/ports/commands.ex
+++ b/lib/core/domain/ports/commands.ex
@@ -23,16 +23,13 @@ defmodule Core.Domain.Ports.Commands do
 
   @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
-  @callback send_invocation_command(worker, Core.Domain.InvokeParams.t()) ::
+  @callback send_invocation_command(worker, Core.Domain.FunctionStruct.t(), Map.t()) ::
               {:ok, %{:result => String.t()}} | {:error, atom}
 
   @doc """
   Sends an invocation command to a worker.
-  It requires a worker (a fully qualified name of another node with the :worker actor on),
-  and invocation parameteres, a map with:
-  - "namespace" => the function's namespace ('_' for the default namespace).
-  - "function" => the function name.
-  - "args" => the invocation arguments.
+  It requires a worker (a fully qualified name of another node with the :worker actor on), a function struct and
+  (optionally empty) function arguments.
   """
-  defdelegate send_invocation_command(worker, ivk_params), to: @adapter
+  defdelegate send_invocation_command(worker, function, args), to: @adapter
 end

--- a/lib/core/domain/ports/function_storage.ex
+++ b/lib/core/domain/ports/function_storage.ex
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+defmodule Core.Domain.Ports.FunctionStorage do
+  @moduledoc """
+  Port for accessing and inserting functions in permanent storage.
+  """
+  alias Core.Domain.FunctionStruct
+
+  @type function_name :: String.t()
+  @type function_namespace :: String.t()
+
+  @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
+
+  @callback init_database() :: :ok | {:error, any}
+  @callback get_function(function_name, function_namespace) ::
+              {:ok, FunctionStruct.t()} | {:error, any}
+  @callback insert_function(FunctionStruct.t()) :: {:ok, function_name} | {:error, any}
+  @callback delete_function(function_name, function_namespace) ::
+              {:ok, function_name} | {:error, any}
+
+  @doc """
+  Creates the Function database.
+  Returns either :ok or {:error, err}.
+
+  The function takes no parameters (the table name is currently just Function by default).
+  """
+  defdelegate init_database(), to: @adapter
+
+  @doc """
+  Gets a function from the function storage.
+  Returns the function itself as a FunctionStruct or an {:error, err} tuple.
+
+  ## Parameters
+    - function_name: Name of the function, unique in a namespace
+    - function_namespace: Namespace the function is in
+
+  """
+  defdelegate get_function(function_name, function_namespace), to: @adapter
+
+  @doc """
+  Inserts a function in the function storage.
+  Returns the inserted function's name or an {:error, err} tuple.
+
+  ## Parameters
+    - function: a FunctionStruct
+
+  """
+  defdelegate insert_function(function), to: @adapter
+
+  @doc """
+  Deletes a function in the function storage.
+  Returns the deleted function's name or an {:error, err} tuple.
+
+  ## Parameters
+    - function_name: Name of the function, unique in a namespace
+    - function_namespace: Namespace the function is in
+  """
+  defdelegate delete_function(function_name, function_namespace), to: @adapter
+end

--- a/lib/core/domain/ports/function_storage.ex
+++ b/lib/core/domain/ports/function_storage.ex
@@ -26,7 +26,7 @@ defmodule Core.Domain.Ports.FunctionStorage do
 
   @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
-  @callback init_database() :: :ok | {:error, any}
+  @callback init_database([Atom.t()]) :: :ok | {:error, any}
   @callback get_function(function_name, function_namespace) ::
               {:ok, FunctionStruct.t()} | {:error, any}
   @callback insert_function(FunctionStruct.t()) :: {:ok, function_name} | {:error, any}
@@ -37,9 +37,10 @@ defmodule Core.Domain.Ports.FunctionStorage do
   Creates the Function database.
   Returns either :ok or {:error, err}.
 
-  The function takes no parameters (the table name is currently just Function by default).
+  ## Parameters
+    - nodes: list of nodes where the database will be created
   """
-  defdelegate init_database(), to: @adapter
+  defdelegate init_database(nodes), to: @adapter
 
   @doc """
   Gets a function from the function storage.

--- a/lib/core/domain/structs.ex
+++ b/lib/core/domain/structs.ex
@@ -29,10 +29,10 @@ defmodule Core.Domain.FunctionStruct do
           namespace: String.t(),
           name: String.t(),
           code: String.t(),
-          language: String.t()
+          image: String.t()
         }
-  @enforce_keys [:name, :namespace, :code, :language]
-  defstruct [:name, :namespace, :code, :language]
+  @enforce_keys [:name, :namespace, :code, :image]
+  defstruct [:name, :namespace, :code, :image]
 end
 
 defmodule Core.Domain.InvokeParams do

--- a/lib/core/domain/structs.ex
+++ b/lib/core/domain/structs.ex
@@ -23,7 +23,7 @@ defmodule Core.Domain.FunctionStruct do
       - name: function name
       - namespace: function namespace
       - code: function code as a string
-      - language: language in which the function is written
+      - image: runtime image corresponding to the language with which the function is written
   """
   @type t :: %__MODULE__{
           namespace: String.t(),

--- a/lib/core/domain/structs.ex
+++ b/lib/core/domain/structs.ex
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+defmodule Core.Domain.FunctionStruct do
+  @moduledoc """
+    Function struct, used for insertion in permanent storage.
+
+    ## Fields
+      - name: function name
+      - namespace: function namespace
+      - code: function code as a string
+      - language: language in which the function is written
+  """
+  @type t :: %__MODULE__{
+          namespace: String.t(),
+          name: String.t(),
+          code: String.t(),
+          language: String.t()
+        }
+  @enforce_keys [:name, :namespace, :code, :language]
+  defstruct [:name, :namespace, :code, :language]
+end
+
+defmodule Core.Domain.InvokeParams do
+  @moduledoc """
+    Invocation parameters struct, used for parameter validation.
+
+    ## Fields
+      - namespace: function namespace
+      - function: function name
+      - args: function arguments
+  """
+  @type t :: %__MODULE__{
+          namespace: String.t(),
+          function: String.t(),
+          args: Map.t()
+        }
+  @enforce_keys [:function]
+  defstruct [:function, namespace: "_", args: %{}]
+end

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule Core.MixProject do
       extra_applications: [:logger, :mnesia],
       mod: {Core.Application, []},
       start_phases: [
-        init_db: []
+        init_db: Mix.env()
       ]
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,10 @@ defmodule Core.MixProject do
   def application do
     [
       extra_applications: [:logger, :mnesia],
-      mod: {Core.Application, []}
+      mod: {Core.Application, []},
+      start_phases: [
+        init_db: []
+      ]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Core.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger],
+      extra_applications: [:logger, :mnesia],
       mod: {Core.Application, []}
     ]
   end

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -42,7 +42,7 @@ defmodule ApiTest do
     test "invoke should return {:ok, result} when there is at least a worker and no error occurs" do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
-      assert Api.invoke(%{"function" => "test"}) == {:ok, %{"result" => "test"}}
+      assert Api.invoke(%{"function" => "test"}) == {:ok, %{result: "test"}}
     end
 
     test "invoke should return {:error, err} when the invocation on worker encounter errors" do

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -33,6 +33,9 @@ defmodule ApiTest do
       Core.Cluster.Mock
       |> Mox.stub_with(Core.Adapters.Cluster.Test)
 
+      Core.FunctionStorage.Mock
+      |> Mox.stub_with(Core.Adapters.FunctionStorage.Test)
+
       :ok
     end
 
@@ -46,7 +49,7 @@ defmodule ApiTest do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invocation_command, fn _, _ ->
+      |> Mox.expect(:send_invocation_command, fn _, _, _ ->
         {:error, %{}}
       end)
 
@@ -61,7 +64,7 @@ defmodule ApiTest do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:core@somewhere, :worker@localhost] end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invocation_command, fn worker, _ -> {:ok, worker} end)
+      |> Mox.expect(:send_invocation_command, fn worker, _, _ -> {:ok, worker} end)
 
       assert Api.invoke(%{"function" => "test"}) == {:ok, :worker@localhost}
     end

--- a/test/http_server_test.exs
+++ b/test/http_server_test.exs
@@ -34,6 +34,9 @@ defmodule HttpServerTest do
       Core.Cluster.Mock
       |> Mox.stub_with(Core.Adapters.Cluster.Test)
 
+      Core.FunctionStorage.Mock
+      |> Mox.stub_with(Core.Adapters.FunctionStorage.Test)
+
       :ok
     end
 
@@ -41,7 +44,7 @@ defmodule HttpServerTest do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invocation_command, fn _, _ ->
+      |> Mox.expect(:send_invocation_command, fn _, _, _ ->
         {:error, %{"error" => "some worker error dude"}}
       end)
 
@@ -76,7 +79,9 @@ defmodule HttpServerTest do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invocation_command, fn _, _ -> {:ok, %{"result" => "Hello, World!"}} end)
+      |> Mox.expect(:send_invocation_command, fn _, _, _ ->
+        {:ok, %{"result" => "Hello, World!"}}
+      end)
 
       # Create a test connection
       conn = conn(:post, "/invoke", %{"namespace" => "_", "function" => "hello", "args" => %{}})

--- a/test/nodes_test.exs
+++ b/test/nodes_test.exs
@@ -55,5 +55,25 @@ defmodule NodesTest do
       workers = Nodes.worker_nodes()
       assert workers == expected
     end
+
+    test "core_nodes should return a list with only the current node when no node is connected" do
+      cores = Nodes.core_nodes()
+      assert cores == [node()]
+    end
+
+    test "core_nodes should return a list with only the current node when there are only non-core nodes" do
+      nodes = [:"worker@example.com", :"extra@127.1.0.2"]
+      Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> nodes end)
+      cores = Nodes.core_nodes()
+      assert cores == [node()]
+    end
+
+    test "core_nodes should return a filtered list of only core nodes when present" do
+      expected = [node(), :"core@ciao.it"]
+      nodes = [:"worker@example.com", :"core@ciao.it", :"extra@127.1.0.2"]
+      Core.Cluster.Mock |> Mox.stub(:all_nodes, fn -> nodes end)
+      cores = Nodes.core_nodes()
+      assert cores == expected
+    end
   end
 end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -18,3 +18,4 @@
 
 Mox.defmock(Core.Commands.Mock, for: Core.Domain.Ports.Commands)
 Mox.defmock(Core.Cluster.Mock, for: Core.Domain.Ports.Cluster)
+Mox.defmock(Core.FunctionStorage.Mock, for: Core.Domain.Ports.FunctionStorage)


### PR DESCRIPTION
This PR adds the possibility for users to store custom functions permanently.
The underlying database implementation uses mnesia.
This closes #33 and #34.