### PR TITLE
Add function storage HTTP endpoints

### DIFF
--- a/core-api.yaml
+++ b/core-api.yaml
@@ -31,6 +31,24 @@ components:
           type: string
         args:
           type: object
+    function_creation:
+      type: object
+      properties:
+        name:
+          type: string
+        namespace:
+          type: string
+        code:
+          type: string
+        image:
+          type: string
+    function_deletion:
+      type: object
+      properties:
+        name:
+          type: string
+        namespace:
+          type: string
 paths:
   /invoke:
     post:
@@ -71,6 +89,16 @@ paths:
                   error:
                     type: string
                     description: The error message
+        "404":
+          description: The required function was not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: The error message
         "500":
           description: The function invocation failed for some unspecified internal error
           content:
@@ -97,7 +125,102 @@ paths:
               examples:
                 Invocation with no workers:
                   value: '{"error": "Failed to invoke function: no worker available"}'
+  /create:
+    post:
+      summary: Create a new function
+      description: >-
+        Creates the given function, extracting the parameters from the POST body
+      requestBody:
+        required: true
+        description: >-
+          Object containing the function to create, with name, optional namespace, code and runtime image identifier
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/function_creation"
+      responses:
+        "200":
+          description: The function was created successfully
+          content:
+            application/json:
+              schema:
+                description: The name of the function
+                type: object
+                properties:
+                  result:
+                    type: object
+              examples:
+                Creation of the "hellojs" function:
+                  value: '{"result": "hellojs"}'
+        "400":
+          description: The function creation request was invalid
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: The error message
+        "500":
+          description: The function creation request failed because the database transaction was aborted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: The error message
+  /delete:
+    post:
+      summary: Delete a function
+      description: >-
+        Deletes the function with the given name and namespace, extracted from the POST body
+      requestBody:
+        required: true
+        description: >-
+          Object containing the name and namespace of the function to delete
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/function_deletion"
+      responses:
+        "200":
+          description: The function was deleted successfully
+          content:
+            application/json:
+              schema:
+                description: The name of the function
+                type: object
+                properties:
+                  result:
+                    type: object
+              examples:
+                Deletion of the "hellojs" function:
+                  value: '{"result": "hellojs"}'
+        "400":
+          description: The function deletion request was invalid
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: The error message
+        "500":
+          description: The function deletion request failed because the database transaction was aborted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: The error message
+
 servers:
-  - url: localhost:4001
+  - url: http://localhost:4001
     variables: {}
     description: The dev server for the funless core launched locally

--- a/lib/core/adapters/requests/http/server.ex
+++ b/lib/core/adapters/requests/http/server.ex
@@ -99,7 +99,7 @@ defmodule Core.Adapters.Requests.Http.Server do
           "Failed to perform the required operation: transaction aborted with reason #{reason}"
       })
 
-    send_resp(conn, 404, body)
+    send_resp(conn, 500, body)
   end
 
   # currently unused, but could be used to handle errors in the future.

--- a/lib/core/adapters/requests/http/server.ex
+++ b/lib/core/adapters/requests/http/server.ex
@@ -43,6 +43,20 @@ defmodule Core.Adapters.Requests.Http.Server do
     reply_to_client(res, conn)
   end
 
+  # Function creation request handler
+  post "/create" do
+    res = Api.new_function(conn.body_params)
+    conn = put_resp_content_type(conn, "application/json", nil)
+    reply_to_client(res, conn)
+  end
+
+  # Function deletion request handler
+  post "/delete" do
+    res = Api.delete_function(conn.body_params)
+    conn = put_resp_content_type(conn, "application/json", nil)
+    reply_to_client(res, conn)
+  end
+
   match _ do
     body = Jason.encode!(%{"error" => "Oops, this endpoint is not implemented yet"})
     conn = put_resp_content_type(conn, "application/json", nil)
@@ -73,6 +87,16 @@ defmodule Core.Adapters.Requests.Http.Server do
     body =
       Jason.encode!(%{
         "error" => "Failed to invoke function: function not found in given namespace"
+      })
+
+    send_resp(conn, 404, body)
+  end
+
+  defp reply_to_client({:error, {:aborted, reason}}, conn) do
+    body =
+      Jason.encode!(%{
+        "error" =>
+          "Failed to perform the required operation: transaction aborted with reason #{reason}"
       })
 
     send_resp(conn, 404, body)

--- a/lib/core/adapters/requests/http/server.ex
+++ b/lib/core/adapters/requests/http/server.ex
@@ -68,14 +68,14 @@ defmodule Core.Adapters.Requests.Http.Server do
     send_resp(conn, 200, body)
   end
 
+  defp reply_to_client({:error, :bad_params}, conn) do
+    body = Jason.encode!(%{"error" => "Failed to perform operation: bad request"})
+    send_resp(conn, 400, body)
+  end
+
   defp reply_to_client({:error, :no_workers}, conn) do
     body = Jason.encode!(%{"error" => "Failed to invoke function: no worker available"})
     send_resp(conn, 503, body)
-  end
-
-  defp reply_to_client({:error, :bad_params}, conn) do
-    body = Jason.encode!(%{"error" => "Failed to invoke function: bad request"})
-    send_resp(conn, 400, body)
   end
 
   defp reply_to_client({:error, :worker_error}, conn) do

--- a/lib/core/domain/api.ex
+++ b/lib/core/domain/api.ex
@@ -105,14 +105,24 @@ defmodule Core.Domain.Api do
       "API: received creation request for function #{function.name} in namespace #{function.namespace}"
     )
 
-    FunctionStorage.insert_function(function)
+    res = FunctionStorage.insert_function(function)
+
+    case res do
+      {:ok, function_name} -> {:ok, %{result: function_name}}
+      err -> err
+    end
   end
 
   def new_function(_), do: {:error, :bad_params}
 
   def delete_function(%{"name" => name, "namespace" => namespace}) do
     Logger.info("API: received deletion request for function #{name} in namespace #{namespace}")
-    FunctionStorage.delete_function(name, namespace)
+    res = FunctionStorage.delete_function(name, namespace)
+
+    case res do
+      {:ok, function_name} -> {:ok, %{result: function_name}}
+      err -> err
+    end
   end
 
   def delete_function(_), do: {:error, :bad_params}

--- a/lib/core/domain/api.ex
+++ b/lib/core/domain/api.ex
@@ -110,8 +110,10 @@ defmodule Core.Domain.Api do
 
   def new_function(_), do: {:error, :bad_params}
 
-  def delete_function(name, namespace) do
+  def delete_function(%{"name" => name, "namespace" => namespace}) do
     Logger.info("API: received deletion request for function #{name} in namespace #{namespace}")
     FunctionStorage.delete_function(name, namespace)
   end
+
+  def delete_function(_), do: {:error, :bad_params}
 end

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -116,7 +116,7 @@ defmodule ApiTest do
       :ok
     end
 
-    test "new_function should return {:ok, function_name} when no error occurs" do
+    test "new_function should return {:ok, %{result: function_name}} when no error occurs" do
       f = %{
         "name" => "hello",
         "namespace" => "ns",
@@ -124,7 +124,7 @@ defmodule ApiTest do
         "image" => "nodejs"
       }
 
-      assert Api.new_function(f) == {:ok, "hello"}
+      assert Api.new_function(f) == {:ok, %{result: "hello"}}
     end
 
     test "new_function should return {:error, :bad_params} when the given parameter map lacks the necessary keys" do
@@ -132,7 +132,7 @@ defmodule ApiTest do
       assert Api.new_function(f) == {:error, :bad_params}
     end
 
-    test "new_function should return {:ok, function_name} and ignore unused parameters in the input map when unnecessary keys are given" do
+    test "new_function should return {:ok, %{result: function_name}} and ignore unused parameters in the input map when unnecessary keys are given" do
       f = %{
         "name" => "hello",
         "code" => "some code",
@@ -152,11 +152,12 @@ defmodule ApiTest do
       end)
       |> Mox.expect(:insert_function, 0, fn _ -> {:error, "some error"} end)
 
-      assert Api.new_function(f) == {:ok, "hello"}
+      assert Api.new_function(f) == {:ok, %{result: "hello"}}
     end
 
-    test "delete_function should return {:ok, function_name} when no error occurs" do
-      assert Api.delete_function(%{"name" => "hello", "namespace" => "ns"}) == {:ok, "hello"}
+    test "delete_function should return {:ok, %{result: function_name}} when no error occurs" do
+      assert Api.delete_function(%{"name" => "hello", "namespace" => "ns"}) ==
+               {:ok, %{result: "hello"}}
     end
 
     test "delete_function should return {:error, :bad_params}  when the given parameter map lacks the necessary keys" do

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -156,7 +156,11 @@ defmodule ApiTest do
     end
 
     test "delete_function should return {:ok, function_name} when no error occurs" do
-      assert Api.delete_function("hello", "ns") == {:ok, "hello"}
+      assert Api.delete_function(%{"name" => "hello", "namespace" => "ns"}) == {:ok, "hello"}
+    end
+
+    test "delete_function should return {:error, :bad_params}  when the given parameter map lacks the necessary keys" do
+      assert Api.delete_function(%{"namespace" => "ns"}) == {:error, :bad_params}
     end
   end
 end

--- a/test/http_server_test.exs
+++ b/test/http_server_test.exs
@@ -109,7 +109,7 @@ defmodule HttpServerTest do
       assert conn.status == 400
       assert get_resp_header(conn, "content-type") == ["application/json"]
       body = Jason.decode!(conn.resp_body)
-      assert body == %{"error" => "Failed to invoke function: bad request"}
+      assert body == %{"error" => "Failed to perform operation: bad request"}
     end
 
     test "should return 400 bad request when empty invoke parameters" do
@@ -124,7 +124,7 @@ defmodule HttpServerTest do
       assert conn.status == 400
       assert get_resp_header(conn, "content-type") == ["application/json"]
       body = Jason.decode!(conn.resp_body)
-      assert body == %{"error" => "Failed to invoke function: bad request"}
+      assert body == %{"error" => "Failed to perform operation: bad request"}
     end
 
     test "should return 404 when the required function is not found" do


### PR DESCRIPTION
This PR adds the `/create` and `/delete` endpoints for function creation and deletion.